### PR TITLE
Queue writes

### DIFF
--- a/shoots/shoots_server.py
+++ b/shoots/shoots_server.py
@@ -240,6 +240,7 @@ class ShootsServer(flight.FlightServerBase):
             os.remove(file_path)
             parquet_exists = False
 
+        logger.debug(f"do_put() called")
         chunks = 0
         while True:
             try:
@@ -248,7 +249,7 @@ class ShootsServer(flight.FlightServerBase):
                 chunks += 1
                 if data_chunk is None:
                     break
-                
+                logger.debug(f"enqueing chunck {chunks}")
                 self._enqueue_write_request(file_path=file_path,
                                         data_table=data_chunk.data,
                                         append = parquet_exists)
@@ -260,6 +261,7 @@ class ShootsServer(flight.FlightServerBase):
             # that the reader has no more data
             except StopIteration:
                 break
+        logger.debug(f"do_put() returning")
 
     def _raise_dataframe_exists_error(self, name):
         exception = {"type":"FileExistsError",

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -196,7 +196,7 @@ class ShootsTestBase(unittest.TestCase):
         self.assertEqual(res["target_rows"], 1000)
 
         df_thousands = self.shoots_client.get("thousand")
-        self.assertEqual(df_thousands.shape[0], 1000)    
+        self.assertEqual(df_thousands.shape[0], 1000, "should be 1000 rows")    
      
         self.shoots_client.delete(name)
         self.shoots_client.delete("thousand")
@@ -256,7 +256,7 @@ class ShootsTestBase(unittest.TestCase):
                              source_bucket=source_bucket,
                              target_bucket=target_bucket)
         
-        self.assertEqual(res["target_rows"], 1000)
+        self.assertEqual(res["target_rows"], 1000, f"actual rows should be 1000")
 
         df_thousands = self.shoots_client.get("thousand",bucket=target_bucket)
         self.assertEqual(df_thousands.shape[0], 1000)    

--- a/tests/queue_test.py
+++ b/tests/queue_test.py
@@ -9,6 +9,7 @@ import queue
 from shoots import ShootsServer, ShootsClient, PutMode, BucketDeleteMode
 from pyarrow.flight import Location
 import logging
+# logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 class QueueTest(unittest.TestCase):
     def setUp(self):

--- a/tests/queue_test.py
+++ b/tests/queue_test.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch
+import threading
+import time
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import queue
+from shoots import ShootsServer, ShootsClient, PutMode
+from pyarrow.flight import Location
+import logging
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+
+class QueueTest(unittest.TestCase):
+    def setUp(self):
+        # Setup server and client as specified
+        location = Location.for_grpc_tcp("localhost", 8085)
+        self.server = ShootsServer(location, "queuebucket")
+        self.client1 = ShootsClient("localhost", 8085)
+        self.client2 = ShootsClient("localhost", 8085)
+        self.client3 = ShootsClient("localhost", 8085)
+        
+
+    def test_concurrent_large_writes_with_delay(self):
+        """
+        Test that three clients writing large dataframes concurrently results in
+        all data being written correctly with a delay added to each write.
+        """
+
+        num_rows = 1000000
+        dataframe1 = pd.DataFrame({'column1': range(num_rows)})
+        dataframe2 = pd.DataFrame({'column1': range(num_rows, 2 * num_rows)})
+        dataframe3 = pd.DataFrame({'column1': range(2 * num_rows, 3 * num_rows)})
+
+        # Function to simulate each client writing its dataframe
+        def client_write(client, dataframe):
+            client.put(
+                name='test_large_write',
+                dataframe=dataframe,
+                mode=PutMode.APPEND,
+                bucket='test_bucket',
+                batch_size=100000  # Adjust as needed
+            )
+
+        # Create threads for each client
+        threads = [
+            threading.Thread(target=client_write, args=(self.client1, dataframe1)),
+            threading.Thread(target=client_write, args=(self.client2, dataframe2)),
+            threading.Thread(target=client_write, args=(self.client3, dataframe3))
+        ]
+
+        # Start all threads
+        for thread in threads:
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        time.sleep(5)
+        result_dataframe = self.client1.get('test_large_write', bucket="test_bucket")
+        # Verify that the total number of rows matches the expected sum
+        expected_num_rows = num_rows * 3
+        actual_num_rows = len(result_dataframe)
+        self.assertEqual(actual_num_rows, expected_num_rows, 
+                         f"Expected {expected_num_rows} rows, but found {actual_num_rows} rows.")
+
+        # Optionally, verify that the data is contiguous (no missing or duplicated ranges)
+        expected_data = pd.concat([dataframe1, dataframe2, dataframe3]).sort_values('column1').reset_index(drop=True)
+        pd.testing.assert_frame_equal(result_dataframe.sort_values('column1').reset_index(drop=True), 
+                                      expected_data,
+                                      check_like=True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As of this PR, the shoots server should be able to handle writes coming from multiple clients. 

- each write is queued
- the specific file_path is locked while it is being written to
- puts are still synchronous (by design)
- there is a test that writes from 3 clients simultaneously

However, while multiple simultaneous writes are now handled, other I/0 operations, such as reads and deletes are not handled and will cause crashes.